### PR TITLE
Add GitHub Skills activity to signup system

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub, and prepare for GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the GitHub Skills activity that was announced by the principal but is missing from the signup system.

## Changes
- Added GitHub Skills activity to the activities dictionary in `src/app.py`
- Includes description about GitHub Certifications program for college applications
- Scheduled for Mondays and Wednesdays, 3:30-4:30 PM
- Capacity for 25 participants
- Ready for immediate student signups

## Resolves
Closes #6 - Missing Activity: GitHub Skills

## Timeline
This resolves the urgent deadline for activity registration closing by the end of the week.